### PR TITLE
Errors Use %d for int Variables

### DIFF
--- a/link_linux.go
+++ b/link_linux.go
@@ -224,7 +224,7 @@ func (l *Link) SetLinkNetInNs(nspid int, ip net.IP, network *net.IPNet, gw *net.
 	}
 
 	if err := netlink.NetworkLinkUp(l.ifc); err != nil {
-		return fmt.Errorf("Unable to bring %s interface UP: %s", l.ifc.Name, nspid)
+		return fmt.Errorf("Unable to bring %s interface UP: %d", l.ifc.Name, nspid)
 	}
 
 	if gw != nil {
@@ -319,7 +319,7 @@ func setLinkOptions(ifc *net.Interface, opts LinkOptions) error {
 				}
 
 				if err := netlink.NetworkLinkUp(ifc); err != nil {
-					return fmt.Errorf("Unable to bring %s interface UP: %s", ifc.Name, ns)
+					return fmt.Errorf("Unable to bring %s interface UP: %d", ifc.Name, ns)
 				}
 			}
 		} else {

--- a/veth_linux.go
+++ b/veth_linux.go
@@ -203,7 +203,7 @@ func (veth *VethPair) SetPeerLinkNetInNs(nspid int, ip net.IP, network *net.IPNe
 	}
 
 	if err := netlink.NetworkLinkUp(veth.peerIfc); err != nil {
-		return fmt.Errorf("Unable to bring %s interface UP: %s", veth.peerIfc.Name, nspid)
+		return fmt.Errorf("Unable to bring %s interface UP: %d", veth.peerIfc.Name, nspid)
 	}
 
 	if gw != nil {

--- a/vlan_linux_test.go
+++ b/vlan_linux_test.go
@@ -33,7 +33,7 @@ func Test_NewVlanLink(t *testing.T) {
 
 		vln, err := NewVlanLink(tt.masterDev, tt.id)
 		if err != nil {
-			t.Fatalf("NewVlanLink(%s, %s) failed to run: %s", tt.masterDev, tt.id, err)
+			t.Fatalf("NewVlanLink(%s, %d) failed to run: %s", tt.masterDev, tt.id, err)
 		}
 
 		vlnName := vln.NetInterface().Name


### PR DESCRIPTION
This fixes multiple error messages that were using `%s` instead of `%d` to represent `int` variables.