### PR TITLE
Set MacAddress on returned objects from WithOptions functions

### DIFF
--- a/macvlan_linux.go
+++ b/macvlan_linux.go
@@ -127,6 +127,13 @@ func NewMacVlanLinkWithOptions(masterDev string, opts MacVlanOptions) (MacVlaner
 				return nil, fmt.Errorf("Incorrect options specified. Attempt to delete the link failed: %s", errDel)
 			}
 		}
+
+		hwaddr, err := net.ParseMAC(opts.MacAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		macVlanIfc.HardwareAddr = hwaddr
 	}
 
 	masterIfc, err := net.InterfaceByName(masterDev)

--- a/macvlan_linux_test.go
+++ b/macvlan_linux_test.go
@@ -64,3 +64,73 @@ func Test_NewMacVlanLink(t *testing.T) {
 		}
 	}
 }
+
+type macvlnWithOptionsTest struct {
+	masterDev string
+	opts      *MacVlanOptions
+}
+
+var macvlnWithOptionsTests = []macvlnWithOptionsTest{
+	{"master01", &MacVlanOptions{Dev: "test", MacAddr: "aa:aa:aa:aa:aa:aa", Mode: "bridge"}},
+}
+
+func Test_NewMacVlanLinkWithOptions(t *testing.T) {
+	for _, tt := range macvlnWithOptionsTests {
+		var iface *net.Interface
+
+		tl := &testLink{}
+
+		if err := tl.prepTestLink(tt.masterDev, "dummy"); err != nil {
+			t.Skipf("NewMacVlanLinkWithOptions test requries external command: %v", err)
+		}
+
+		if err := tl.create(); err != nil {
+			t.Fatalf("testLink.create failed: %v", err)
+		} else {
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		mvln, err := NewMacVlanLinkWithOptions(tt.masterDev, *tt.opts)
+		if err != nil {
+			t.Fatalf("NewMacVlanLinkWithOptions(%s, %s) failed to run: %s", tt.masterDev, *tt.opts, err)
+		}
+
+		iface = mvln.NetInterface()
+
+		if iface.HardwareAddr.String() != tt.opts.MacAddr {
+			tl.teardown()
+			t.Fatalf("NewMacVlanLinkWithOptions(%s, %s) failed: expected %s, returned %s",
+				tt.masterDev, *tt.opts, tt.opts.MacAddr, iface.HardwareAddr.String())
+		}
+
+		mvlnName := iface.Name
+		if _, err := net.InterfaceByName(mvlnName); err != nil {
+			tl.teardown()
+			t.Fatalf("Could not find %s on the host: %s", mvlnName, err)
+		}
+
+		testRes, err := linkInfo(mvlnName, "macvlan")
+		if err != nil {
+			tl.teardown()
+			t.Fatalf("Failed to list %s operation mode: %s", mvlnName, err)
+		}
+
+		if testRes.linkType != "macvlan" {
+			tl.teardown()
+			t.Fatalf("NewMacVlanLinkWithOptions(%s, %s) failed: expected macvlan, returned %s",
+				tt.masterDev, *tt.opts, testRes.linkType)
+		}
+
+		if testRes.linkData != "bridge" {
+			tl.teardown()
+			t.Fatalf("NewMacVlanLinkWithOptions(%s, %s) failed: expected bridge, returned %s",
+				tt.masterDev, *tt.opts, testRes.linkData)
+		}
+
+		if err := tl.teardown(); err != nil {
+			t.Fatalf("testLink.teardown failed: %v", err)
+		} else {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}

--- a/macvtap_linux.go
+++ b/macvtap_linux.go
@@ -97,6 +97,13 @@ func NewMacVtapLinkWithOptions(masterDev string, opts MacVlanOptions) (MacVtaper
 					errDel)
 			}
 		}
+
+		hwaddr, err := net.ParseMAC(opts.MacAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		macVtapIfc.HardwareAddr = hwaddr
 	}
 
 	masterIfc, err := net.InterfaceByName(masterDev)

--- a/macvtap_linux_test.go
+++ b/macvtap_linux_test.go
@@ -64,3 +64,73 @@ func Test_NewMacVtapLink(t *testing.T) {
 		}
 	}
 }
+
+type macvtpWithOptionsTest struct {
+	masterDev string
+	opts      *MacVlanOptions
+}
+
+var macvtpWithOptionsTests = []macvtpWithOptionsTest{
+	{"master01", &MacVlanOptions{Dev: "test", MacAddr: "aa:aa:aa:aa:aa:aa", Mode: "bridge"}},
+}
+
+func Test_NewMacVtapLinkWithOptions(t *testing.T) {
+	for _, tt := range macvtpWithOptionsTests {
+		var iface *net.Interface
+
+		tl := &testLink{}
+
+		if err := tl.prepTestLink(tt.masterDev, "dummy"); err != nil {
+			t.Skipf("NewMacVtapLinkWithOptions test requries external command: %v", err)
+		}
+
+		if err := tl.create(); err != nil {
+			t.Fatalf("testLink.create failed: %v", err)
+		} else {
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		macvtp, err := NewMacVtapLinkWithOptions(tt.masterDev, *tt.opts)
+		if err != nil {
+			t.Fatalf("NewMacVtapLinkWithOptions(%s, %s) failed to run: %s", tt.masterDev, *tt.opts, err)
+		}
+
+		iface = macvtp.NetInterface()
+
+		if iface.HardwareAddr.String() != tt.opts.MacAddr {
+			tl.teardown()
+			t.Fatalf("NewMacVtapLinkWithOptions(%s, %s) failed: expected %s, returned %s",
+				tt.masterDev, *tt.opts, tt.opts.MacAddr, iface.HardwareAddr.String())
+		}
+
+		mvtpName := iface.Name
+		if _, err := net.InterfaceByName(mvtpName); err != nil {
+			tl.teardown()
+			t.Fatalf("Could not find %s on the host: %s", mvtpName, err)
+		}
+
+		testRes, err := linkInfo(mvtpName, "macvtap")
+		if err != nil {
+			tl.teardown()
+			t.Fatalf("Failed to list %s operation mode: %s", mvtpName, err)
+		}
+
+		if testRes.linkType != "macvtap" {
+			tl.teardown()
+			t.Fatalf("NewMacVtapLinkWithOptions(%s, %s) failed: expected macvtap, returned %s",
+				tt.masterDev, *tt.opts, testRes.linkType)
+		}
+
+		if testRes.linkData != "bridge" {
+			tl.teardown()
+			t.Fatalf("NewMacVtapLinkWithOptions(%s, %s) failed: expected bridge, returned %s",
+				tt.masterDev, *tt.opts, testRes.linkData)
+		}
+
+		if err := tl.teardown(); err != nil {
+			t.Fatalf("testLink.teardown failed: %v", err)
+		} else {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}

--- a/vlan_linux.go
+++ b/vlan_linux.go
@@ -119,6 +119,13 @@ func NewVlanLinkWithOptions(masterDev string, opts VlanOptions) (Vlaner, error) 
 					errDel)
 			}
 		}
+
+		hwaddr, err := net.ParseMAC(opts.MacAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		vlanIfc.HardwareAddr = hwaddr
 	}
 
 	masterIfc, err := net.InterfaceByName(masterDev)


### PR DESCRIPTION
Bugfix returned object from `NewMacVlanLinkWithOptions`, `NewMacVtapLinkWithOptions` and `NewVlanLinkWithOptions` to include the new MacAddress.
Added matching tests.