### PR TITLE
Test with docker - make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+test:
+	docker-compose run --rm test make _test
+
+_test:
+	go test
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  test:
+    image: golang
+    cap_add:
+      - CAP_NET_ADMIN
+    volumes:
+      - ${PWD}:/src
+      - ${HOME}/.cache/go-build:/go/pkg/mod
+    working_dir: /src
+    environment:
+      - GOCACHE=/go/pkg/mod


### PR DESCRIPTION
Instead of using a `Vagrantfile` and bringing up a VM - Just use a docker with CAP_NET_ADMIN capability.
Can run with `make test`